### PR TITLE
Add multi_json to development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.10
-  - 2.5.8
-  - 2.6.6
-  - 2.7.1
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3
 
 gemfile:
   - gemfiles/rails_3.2.gemfile
@@ -52,31 +52,31 @@ jobs:
     - rvm: 2.4.10
       gemfile: gemfiles/rails_6.0.gemfile
 
-    - rvm: 2.5.8
+    - rvm: 2.5.9
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.5.8
+    - rvm: 2.5.9
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 2.5.8
+    - rvm: 2.5.9
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.5.8
+    - rvm: 2.5.9
       gemfile: gemfiles/rails_4.2.gemfile
 
-    - rvm: 2.6.6
+    - rvm: 2.6.7
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.6.6
+    - rvm: 2.6.7
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 2.6.6
+    - rvm: 2.6.7
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.6.6
+    - rvm: 2.6.7
       gemfile: gemfiles/rails_4.2.gemfile
 
-    - rvm: 2.7.1
+    - rvm: 2.7.3
       gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.7.1
+    - rvm: 2.7.3
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 2.7.1
+    - rvm: 2.7.3
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.7.1
+    - rvm: 2.7.3
       gemfile: gemfiles/rails_4.2.gemfile
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.5.9
   - 2.6.7
   - 2.7.3
+  - 3.0.1
 
 gemfile:
   - gemfiles/rails_3.2.gemfile
@@ -78,6 +79,27 @@ jobs:
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: 2.7.3
       gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.7.3
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 2.7.3
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 2.7.3
+      gemfile: gemfiles/rails_5.2.gemfile
+
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_4.0.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 3.0.1
+      gemfile: gemfiles/rails_5.2.gemfile
 
 cache: bundler
 

--- a/eaco.gemspec
+++ b/eaco.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard-cucumber"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "guard-shell"
+  spec.add_development_dependency "multi_json"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "pg"
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'rails'
 require 'byebug'
+require 'multi_json'
 
 require 'eaco/coverage'
 Eaco::Coverage.start!

--- a/lib/eaco/coverage.rb
+++ b/lib/eaco/coverage.rb
@@ -76,6 +76,7 @@ module Eaco
       proc do
         gemfile = Eaco::Rake::Utils.gemfile
         coverage_dir "coverage/#{gemfile}"
+        add_filter ['/features', '/spec']
       end
     end
   end


### PR DESCRIPTION
`multi_json` is no longer required by new versions of Cucumber. This
commit explicitly requires the dependency because it is used in a
couple of features